### PR TITLE
Fix free phase objectives

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumCollocation"
 uuid = "0dc23a59-5ffb-49af-b6bd-932a8ae77adf"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/constraints/fidelity_constraint.jl
+++ b/src/constraints/fidelity_constraint.jl
@@ -286,8 +286,8 @@ function FinalUnitaryFreePhaseFidelityConstraint(;
 end
 
 function FinalUnitaryFreePhaseFidelityConstraint(
-    state_symbol::Symbol,
-    global_symbol::Symbol,
+    state_name::Symbol,
+    phase_name::Symbol,
     phase_operators::AbstractVector{<:AbstractMatrix{<:Complex}},
     val::Float64,
     traj::NamedTrajectory;
@@ -296,9 +296,9 @@ function FinalUnitaryFreePhaseFidelityConstraint(
 )
     return FinalUnitaryFreePhaseFidelityConstraint(;
         value=val,
-        state_slice=slice(traj.T, traj.components[state_symbol], traj.dim),
-        phase_slice=trajectory.global_components[global_symbol],
-        goal=traj.goal[state_symbol],
+        state_slice=slice(traj.T, traj.components[state_name], traj.dim),
+        phase_slice=traj.global_components[phase_name],
+        goal=traj.goal[state_name],
         phase_operators=phase_operators,
         zdim=length(traj),
         subspace=subspace,

--- a/src/isomorphisms.jl
+++ b/src/isomorphisms.jl
@@ -59,9 +59,22 @@ Convert a real vector `Ũ⃗` into a complex matrix representing an operator.
 Must be differentiable.
 """
 function iso_vec_to_operator(Ũ⃗::AbstractVector{R}) where R
+    if !(R <: Real)
+        try
+            Ũ⃗ = convert(Vector{Real}, Ũ⃗)
+        catch 
+            throw(TypeError(
+                :iso_vec_to_operator,
+                "unable to convert input to a Real vector",
+                Real,
+                R
+            ))
+        end
+    end
+
     Ũ⃗_dim = div(length(Ũ⃗), 2)
     N = Int(sqrt(Ũ⃗_dim))
-    U = Matrix{complex(R)}(undef, N, N)
+    U = Matrix{complex(eltype(Ũ⃗))}(undef, N, N)
     for i=0:N-1
         U[:, i+1] .= @view(Ũ⃗[i * 2N .+ (1:N)]) + one(R) * im * @view(Ũ⃗[i * 2N .+ (N+1:2N)])
     end
@@ -99,8 +112,21 @@ Convert a complex matrix `U` representing an operator into a real vector.
 Must be differentiable.
 """
 function operator_to_iso_vec(U::AbstractMatrix{R}) where R
+    if !(R <: Number)
+        try
+            U = convert(Matrix{Complex}, U)
+        catch 
+            throw(TypeError(
+                :operator_to_iso_vec,
+                "unable to convert input to a Complex matrix",
+                Number,
+                R
+            ))
+        end
+    end
+
     N = size(U,1)
-    Ũ⃗ = Vector{real(R)}(undef, N^2 * 2)
+    Ũ⃗ = Vector{real(eltype(U))}(undef, N^2 * 2)
     for i=0:N-1
         Ũ⃗[i*2N .+ (1:N)] .= real(@view(U[:, i+1]))
         Ũ⃗[i*2N .+ (N+1:2N)] .= imag(@view(U[:, i+1]))

--- a/src/losses/_losses.jl
+++ b/src/losses/_losses.jl
@@ -16,6 +16,9 @@ using ForwardDiff
 using Symbolics
 using TestItemRunner
 
+# For differentiable exponential
+using ExponentialAction
+
 # TODO:
 # - [ ] Do not reference the Z object in the loss (components only / remove "name")
 

--- a/src/losses/unitary_infidelity_loss.jl
+++ b/src/losses/unitary_infidelity_loss.jl
@@ -30,9 +30,12 @@ where $n$ is the dimension of the unitary operators.
     U_goal::Matrix;
     subspace::AbstractVector{Int}=axes(U_goal, 1)
 )
-    U_goal = U_goal[subspace, subspace]
-    U = U[subspace, subspace]
-    return 1 / size(U_goal, 1) * abs(tr(U_goal'U))
+    # avoids type coercion neceessary because tr(Matrix{Any}) fails
+    return iso_vec_unitary_fidelity(
+        operator_to_iso_vec(U),
+        operator_to_iso_vec(U_goal),
+        subspace=subspace
+    )
 end
 
 
@@ -240,7 +243,6 @@ function free_phase(
     return reduce(kron, [expv(im * ϕ, H, Id) for (ϕ, H) ∈ zip(ϕs, Hs)])
 end
 
-# TODO: in-place
 function free_phase_gradient(
     ϕs::AbstractVector,
     Hs::AbstractVector{<:AbstractMatrix}

--- a/src/objectives/unitary_infidelity_objective.jl
+++ b/src/objectives/unitary_infidelity_objective.jl
@@ -151,10 +151,15 @@ function UnitaryFreePhaseInfidelityObjective(;
     end
 
     @views function ∇L(Z⃗::AbstractVector{<:Real}, Z::NamedTrajectory)
-        # TODO: implement analytic
-        ∇ = ForwardDiff.gradient(Z⃗ -> L(Z⃗, Z), Z⃗)
-        # println(nnz(sparse(∇)))
-        # println(∇[Z.global_components[global_name]])
+        ∇ = zeros(Z.dim * Z.T + Z.global_dim)
+        Ũ⃗_slice = slice(Z.T, Z.components[name], Z.dim)
+        Ũ⃗ = Z⃗[Ũ⃗_slice]
+        ϕ⃗_slice = Z.global_components[phase_name]
+        ϕ⃗ = Z⃗[ϕ⃗_slice]
+        ∇l = l(Ũ⃗, ϕ⃗; gradient=true)
+        ∇[Ũ⃗_slice] = Q * ∇l[1:length(Ũ⃗)]
+        # WARNING: 2π periodic; using Q≠1 is not recommended
+        ∇[ϕ⃗_slice] = Q * ∇l[length(Ũ⃗) .+ (1:length(ϕ⃗))]
         return ∇
     end
 

--- a/src/objectives/unitary_infidelity_objective.jl
+++ b/src/objectives/unitary_infidelity_objective.jl
@@ -119,8 +119,8 @@ Fields:
 """
 function UnitaryFreePhaseInfidelityObjective(;
     name::Union{Nothing,Symbol}=nothing,
-    phase_name::Union{Nothing,Symbol}=nothing,
     goal::Union{Nothing,AbstractVector{<:R}}=nothing,
+    phase_name::Union{Nothing,Symbol}=nothing,
     phase_operators::Union{Nothing,AbstractVector{<:AbstractMatrix{<:Complex{R}}}}=nothing,
 	Q::R=1.0,
 	eval_hessian::Bool=false,
@@ -167,4 +167,24 @@ function UnitaryFreePhaseInfidelityObjective(;
     ∂²L(Z⃗::AbstractVector{<:Real}, Z::NamedTrajectory) = []
 
 	return Objective(L, ∇L, ∂²L, ∂²L_structure, Dict[params])
+end
+
+function UnitaryFreePhaseInfidelityObjective(
+    name::Symbol,
+    phase_name::Symbol,
+    phase_operators::AbstractVector{<:AbstractMatrix{<:Complex}},
+    traj::NamedTrajectory,
+    Q::Float64;
+    subspace=nothing,
+	eval_hessian::Bool=true
+)
+    return UnitaryFreePhaseInfidelityObjective(
+        name=name,
+        goal=traj.goal[name],
+        phase_name=phase_name,
+        phase_operators=phase_operators,
+        Q=Q,
+        subspace=subspace,
+        eval_hessian=eval_hessian,
+    )
 end

--- a/src/problem_templates/_problem_templates.jl
+++ b/src/problem_templates/_problem_templates.jl
@@ -1,5 +1,6 @@
 module ProblemTemplates
 
+using ..QuantumObjectUtils
 using ..QuantumSystems
 using ..Isomorphisms
 using ..EmbeddedOperators

--- a/src/problem_templates/unitary_minimum_time_problem.jl
+++ b/src/problem_templates/unitary_minimum_time_problem.jl
@@ -52,11 +52,12 @@ function UnitaryMinimumTimeProblem(
     integrators::Vector{<:AbstractIntegrator},
     constraints::Vector{<:AbstractConstraint};
     unitary_name::Symbol=:Ũ⃗,
-    global_name::Union{Nothing, Symbol}=nothing,
     final_fidelity::Union{Real, Nothing}=nothing,
     D=1.0,
     ipopt_options::IpoptOptions=IpoptOptions(),
     piccolo_options::PiccoloOptions=PiccoloOptions(),
+    phase_name::Symbol=:ϕ,
+    phase_operators::Union{AbstractVector{<:AbstractMatrix}, Nothing}=nothing,
     subspace=nothing,
     kwargs...
 )
@@ -70,7 +71,7 @@ function UnitaryMinimumTimeProblem(
 
     objective += MinimumTimeObjective(trajectory; D=D, eval_hessian=piccolo_options.eval_hessian)
 
-    if isnothing(global_name)
+    if isnothing(phase_operators)
         fidelity_constraint = FinalUnitaryFidelityConstraint(
             unitary_name,
             final_fidelity,
@@ -79,12 +80,9 @@ function UnitaryMinimumTimeProblem(
             eval_hessian=piccolo_options.eval_hessian
         )
     else
-        phase_operators= [
-            GATES[:Z] for _ in eachindex(trajectory.global_components[global_name])
-        ]
         fidelity_constraint = FinalUnitaryFreePhaseFidelityConstraint(
             unitary_name,
-            global_name,
+            phase_name,
             phase_operators,
             final_fidelity,
             trajectory;

--- a/src/problem_templates/unitary_robustness_problem.jl
+++ b/src/problem_templates/unitary_robustness_problem.jl
@@ -39,24 +39,25 @@ function UnitaryRobustnessProblem(
     phase_operators::Union{AbstractVector{<:AbstractMatrix}, Nothing}=nothing,
     ipopt_options::IpoptOptions=IpoptOptions(),
     piccolo_options::PiccoloOptions=PiccoloOptions(),
+    subspace=nothing,
     kwargs...
 )
     @assert unitary_name ∈ trajectory.names
 
-    if isnothing(final_fidelity)
-        final_fidelity = unitary_fidelity(
-            trajectory[unitary_name][:, end], trajectory.goal[unitary_name]
-        )
-    end
-
     objective += UnitaryRobustnessObjective(
         H_error=H_error,
-        eval_hessian=piccolo_options.eval_hessian,
+        eval_hessian=piccolo_options.eval_hessian
     )
 
-    subspace = H_error isa EmbeddedOperator ? H_error.subspace_indices : nothing
-
     if isnothing(phase_operators)
+        if isnothing(final_fidelity)
+            final_fidelity = iso_vec_unitary_fidelity(
+                trajectory[unitary_name][:, end], 
+                trajectory.goal[unitary_name],
+                subspace=subspace
+            )
+        end
+        
         fidelity_constraint = FinalUnitaryFidelityConstraint(
             unitary_name,
             final_fidelity,
@@ -65,6 +66,16 @@ function UnitaryRobustnessProblem(
             eval_hessian=piccolo_options.eval_hessian
         )
     else
+        if isnothing(final_fidelity)
+            final_fidelity = iso_vec_unitary_free_phase_fidelity(
+                trajectory[unitary_name][:, end], 
+                trajectory.goal[unitary_name], 
+                trajectory.global_data[phase_name],
+                phase_operators;
+                subspace=subspace
+            )
+        end
+
         fidelity_constraint = FinalUnitaryFreePhaseFidelityConstraint(
             unitary_name,
             phase_name,
@@ -163,4 +174,45 @@ end
 
     # TODO: Fidelity constraint approximately satisfied
     @test_skip isapprox(unitary_fidelity(rob_prob; subspace=U_goal.subspace_indices), 0.99, atol=0.05)
+end
+
+@testitem "Set up a free phase problem" begin
+    using LinearAlgebra
+    δ1 = δ2 = -0.1
+    T = 75
+    Δt = 1.0
+    n_levels = 3
+    a = annihilate(n_levels)
+    id = I(n_levels)
+    a1 = kron(a, id)
+    a2 = kron(id, a)
+    H_drift = δ1 / 2 * a1' * a1' * a1 * a1 + δ2 / 2 * a2' * a2' * a2 * a2
+    H_drives = [a1'a1, a2'a2, a1'a2 + a1*a2', im * (a1'a2 - a1 * a2')]
+    system = QuantumSystem(H_drift, H_drives)
+    U_goal = EmbeddedOperator(
+        GATES[:CZ], 
+        get_subspace_indices([1:2, 1:2], [n_levels, n_levels]),
+        [n_levels, n_levels]
+    )
+
+    phase_operators = [PAULIS[:Z], PAULIS[:Z]]
+    prob = UnitarySmoothPulseProblem(
+        system, U_goal, T, Δt,
+        ipopt_options=IpoptOptions(print_level=1),
+        piccolo_options=PiccoloOptions(verbose=false, eval_hessian=false),
+        phase_operators=phase_operators,
+    )
+
+    ZZ = EmbeddedOperator(
+        reduce(kron, phase_operators), 
+        get_subspace_indices([1:2, 1:2], [n_levels, n_levels]), 
+        [n_levels, n_levels]
+    )
+
+    @test UnitaryRobustnessProblem(
+        ZZ,
+        prob,
+        phase_operators=phase_operators,
+        subspace=U_goal.subspace_indices,
+    ) isa QuantumControlProblem
 end

--- a/src/problem_templates/unitary_sampling_problem.jl
+++ b/src/problem_templates/unitary_sampling_problem.jl
@@ -33,7 +33,6 @@ robust solution by including multiple systems reflecting the problem uncertainty
 - `dda_bounds::Vector{Float64} = fill(dda_bound, length(systems[1].G_drives))`: The bounds for the control second derivatives.
 - `Δt_min::Float64 = 0.5 * Δt`: The minimum time step size.
 - `Δt_max::Float64 = 1.5 * Δt`: The maximum time step size.
-- `drive_derivative_σ::Float64 = 0.01`: The standard deviation for the drive derivative noise.
 - `Q::Float64 = 100.0`: The fidelity weight.
 - `R::Float64 = 1e-2`: The regularization weight.
 - `R_a::Union{Float64, Vector{Float64}} = R`: The regularization weight for the control amplitudes.
@@ -64,7 +63,6 @@ function UnitarySamplingProblem(
     dda_bounds::Vector{Float64}=fill(dda_bound, length(systems[1].G_drives)),
     Δt_min::Float64=0.5 * Δt,
     Δt_max::Float64=1.5 * Δt,
-    drive_derivative_σ::Float64=0.01,
     Q::Float64=100.0,
     R=1e-2,
     R_a::Union{Float64,Vector{Float64}}=R,

--- a/src/problem_templates/unitary_sampling_problem.jl
+++ b/src/problem_templates/unitary_sampling_problem.jl
@@ -89,7 +89,6 @@ function UnitarySamplingProblem(
             Δt_bounds=(Δt_min, Δt_max),
             geodesic=piccolo_options.geodesic,
             bound_state=piccolo_options.bound_state,
-            drive_derivative_σ=drive_derivative_σ,
             a_guess=a_guess,
             system=systems,
             rollout_integrator=piccolo_options.rollout_integrator,

--- a/src/problem_templates/unitary_smooth_pulse_problem.jl
+++ b/src/problem_templates/unitary_smooth_pulse_problem.jl
@@ -62,7 +62,8 @@ with
 - `R_a::Union{Float64, Vector{Float64}}=R`: the weight on the regularization term for the control pulses
 - `R_da::Union{Float64, Vector{Float64}}=R`: the weight on the regularization term for the control pulse derivatives
 - `R_dda::Union{Float64, Vector{Float64}}=R`: the weight on the regularization term for the control pulse second derivatives
-- `global_data::Union{NamedTuple, Nothing}=nothing`: global data for the problem
+- `phase_name::Symbol=:ϕ`: the name of the phase
+- `phase_operators::Union{AbstractVector{<:AbstractMatrix}, Nothing}=nothing`: the phase operators for free phase corrections
 - `constraints::Vector{<:AbstractConstraint}=AbstractConstraint[]`: the constraints to enforce
 
 """
@@ -92,7 +93,8 @@ function UnitarySmoothPulseProblem(
     R_a::Union{Float64, Vector{Float64}}=R,
     R_da::Union{Float64, Vector{Float64}}=R,
     R_dda::Union{Float64, Vector{Float64}}=R,
-    global_data::Union{NamedTuple, Nothing}=nothing,
+    phase_name::Symbol=:ϕ,
+    phase_operators::Union{AbstractVector{<:AbstractMatrix}, Nothing}=nothing,
     constraints::Vector{<:AbstractConstraint}=AbstractConstraint[],
     kwargs...
 )
@@ -120,31 +122,26 @@ function UnitarySmoothPulseProblem(
             a_guess=a_guess,
             system=system,
             rollout_integrator=piccolo_options.rollout_integrator,
-            global_data=global_data
+            phase_name=phase_name,
+            phase_operators=phase_operators
         )
     end
 
     # Subspace
     subspace = operator isa EmbeddedOperator ? operator.subspace_indices : nothing
-    goal = operator_to_iso_vec(operator isa EmbeddedOperator ? operator.operator : operator)
 
     # Objective
-    if isnothing(global_data)
+    if isnothing(phase_operators)
         J = UnitaryInfidelityObjective(
             state_name, traj, Q; 
             subspace=subspace,
             eval_hessian=piccolo_options.eval_hessian,
         )
     else
-        # TODO: remove hardcoded args
         J = UnitaryFreePhaseInfidelityObjective(
-            name=state_name,
-            phase_name=:ϕ,
-            goal=goal,
-            phase_operators=fill(GATES[:Z], length(traj.global_components[:ϕ])),
-            Q=Q,
+            state_name, phase_name, phase_operators, traj, Q;
+            subspace=subspace,
             eval_hessian=piccolo_options.eval_hessian,
-            subspace=subspace
         )
     end
 

--- a/src/problem_templates/unitary_smooth_pulse_problem.jl
+++ b/src/problem_templates/unitary_smooth_pulse_problem.jl
@@ -56,7 +56,6 @@ with
 - `dda_bounds::Vector{Float64}=fill(dda_bound, length(system.G_drives))`: the bounds on the control pulse second derivatives, one for each drive
 - `Δt_min::Float64=Δt isa Float64 ? 0.5 * Δt : 0.5 * mean(Δt)`: the minimum time step size
 - `Δt_max::Float64=Δt isa Float64 ? 1.5 * Δt : 1.5 * mean(Δt)`: the maximum time step size
-- `drive_derivative_σ::Float64=0.01`: the standard deviation of the initial guess for the control pulse derivatives
 - `Q::Float64=100.0`: the weight on the infidelity objective
 - `R=1e-2`: the weight on the regularization terms
 - `R_a::Union{Float64, Vector{Float64}}=R`: the weight on the regularization term for the control pulses
@@ -87,7 +86,6 @@ function UnitarySmoothPulseProblem(
     dda_bounds::Vector{Float64}=fill(dda_bound, length(system.G_drives)),
     Δt_min::Float64=Δt isa Float64 ? 0.5 * Δt : 0.5 * mean(Δt),
     Δt_max::Float64=Δt isa Float64 ? 1.5 * Δt : 1.5 * mean(Δt),
-    drive_derivative_σ::Float64=0.01,
     Q::Float64=100.0,
     R=1e-2,
     R_a::Union{Float64, Vector{Float64}}=R,
@@ -118,7 +116,6 @@ function UnitarySmoothPulseProblem(
             Δt_bounds=(Δt_min, Δt_max),
             geodesic=piccolo_options.geodesic,
             bound_state=piccolo_options.bound_state,
-            drive_derivative_σ=drive_derivative_σ,
             a_guess=a_guess,
             system=system,
             rollout_integrator=piccolo_options.rollout_integrator,

--- a/src/problem_templates/unitary_smooth_pulse_problem.jl
+++ b/src/problem_templates/unitary_smooth_pulse_problem.jl
@@ -124,25 +124,27 @@ function UnitarySmoothPulseProblem(
         )
     end
 
+    # Subspace
+    subspace = operator isa EmbeddedOperator ? operator.subspace_indices : nothing
+    goal = operator_to_iso_vec(operator isa EmbeddedOperator ? operator.operator : operator)
+
     # Objective
     if isnothing(global_data)
-        J = UnitaryInfidelityObjective(state_name, traj, Q;
-            subspace=operator isa EmbeddedOperator ? operator.subspace_indices : nothing,
+        J = UnitaryInfidelityObjective(
+            state_name, traj, Q; 
+            subspace=subspace,
+            eval_hessian=piccolo_options.eval_hessian,
         )
     else
         # TODO: remove hardcoded args
         J = UnitaryFreePhaseInfidelityObjective(
             name=state_name,
             phase_name=:ϕ,
-            goal=operator_to_iso_vec(
-                operator isa EmbeddedOperator ?
-                operator.operator :
-                operator
-            ),
+            goal=goal,
             phase_operators=fill(GATES[:Z], length(traj.global_components[:ϕ])),
             Q=Q,
             eval_hessian=piccolo_options.eval_hessian,
-            subspace=operator isa EmbeddedOperator ? operator.subspace_indices : nothing
+            subspace=subspace
         )
     end
 

--- a/src/rollouts.jl
+++ b/src/rollouts.jl
@@ -82,6 +82,7 @@ function rollout(
 )
     T = size(controls, 2)
 
+    # Real type enables ForwardDiff
     Ψ̃ = zeros(Real, length(ψ̃_init), T)
 
     Ψ̃[:, 1] .= ψ̃_init
@@ -179,6 +180,7 @@ function open_rollout(
 )
     T = size(controls, 2)
 
+    # Real type enables ForwardDiff
     ρ⃗̃ = zeros(Real, 2length(ρ⃗₁), T)
 
     ρ⃗̃[:, 1] .= ket_to_iso(ρ⃗₁)
@@ -222,6 +224,7 @@ function unitary_rollout(
 )
     T = size(controls, 2)
 
+    # Real type enables ForwardDiff
     Ũ⃗ = zeros(Real, length(Ũ⃗_init), T)
 
     Ũ⃗[:, 1] .= Ũ⃗_init
@@ -272,6 +275,9 @@ function unitary_rollout(
     )
 end
 
+"""
+Compute the rollout fidelity.
+"""
 function Losses.iso_vec_unitary_fidelity(
     Ũ⃗_init::AbstractVector{<:Real},
     Ũ⃗_goal::AbstractVector{<:Real},
@@ -279,10 +285,16 @@ function Losses.iso_vec_unitary_fidelity(
     Δt::AbstractVector,
     system::AbstractQuantumSystem;
     subspace::AbstractVector{Int}=axes(iso_vec_to_operator(Ũ⃗_goal), 1),
+    phases::Union{Nothing, AbstractVector{<:Real}}=nothing,
+    phase_operators::Union{Nothing, AbstractVector{<:AbstractMatrix{<:Complex}}}=nothing,
     kwargs...
 )
-    Ũ⃗ = unitary_rollout(Ũ⃗_init, controls, Δt, system; kwargs...)
-    return iso_vec_unitary_fidelity(Ũ⃗[:, end], Ũ⃗_goal; subspace=subspace)
+    Ũ⃗_T = unitary_rollout(Ũ⃗_init, controls, Δt, system; kwargs...)[:, end]
+    if !isnothing(phases)
+        return iso_vec_unitary_free_phase_fidelity(Ũ⃗_T, Ũ⃗_goal, phases, phase_operators; subspace=subspace)
+    else
+        return iso_vec_unitary_fidelity(Ũ⃗_T, Ũ⃗_goal; subspace=subspace)
+    end
 end
 
 function Losses.iso_vec_unitary_fidelity(

--- a/src/rollouts.jl
+++ b/src/rollouts.jl
@@ -474,6 +474,9 @@ end
     @test unitary_fidelity(prob) ≈ 1
     @test unitary_fidelity(embedded_U_goal, as, ts, sys) ≈ 1
 
+    # Free phase unitary
+    @test unitary_fidelity(prob, phases=[0.0], phase_operators=[PAULIS[:Z]]) ≈ 1
+
     # Expv explicit
     # State fidelity
     @test fidelity(ψ, ψ_goal, as, ts, sys, integrator=expv) ≈ 1

--- a/src/trajectory_initialization.jl
+++ b/src/trajectory_initialization.jl
@@ -276,7 +276,8 @@ function initialize_trajectory(
     Δt_bounds::ScalarBound=(0.5 * Δt, 1.5 * Δt),
     drive_derivative_σ::Float64=0.1,
     a_guess::Union{AbstractMatrix{<:Float64}, Nothing}=nothing,
-    global_data::Union{NamedTuple, Nothing}=nothing,
+    phase_name::Symbol=:ϕ,
+    phase_data::Union{AbstractVector{<:Real}, Nothing}=nothing,
     verbose=false,
 )
     @assert length(state_data) == length(state_names) == length(state_inits) == length(state_goals) "state_data, state_names, state_inits, and state_goals must have the same length"
@@ -361,6 +362,9 @@ function initialize_trajectory(
         controls = (control_names[end],)
     end
 
+    # Construct global data for free phases
+    global_data = isnothing(phase_data) ? (;) : (; phase_name => phase_data)
+
     return NamedTrajectory(
         (; (names .=> values)...);
         controls=controls,
@@ -369,7 +373,7 @@ function initialize_trajectory(
         initial=initial,
         final=final,
         goal=goal,
-        global_data= isnothing(global_data) ? (;) : global_data
+        global_data=global_data
     )
 end
 
@@ -422,6 +426,7 @@ function initialize_trajectory(
     system::Union{AbstractQuantumSystem, AbstractVector{<:AbstractQuantumSystem}, Nothing}=nothing,
     rollout_integrator::Function=expv,
     geodesic=true,
+    phase_operators::Union{AbstractVector{<:AbstractMatrix}, Nothing}=nothing,
     verbose=false,
     kwargs...
 )
@@ -475,6 +480,9 @@ function initialize_trajectory(
         state_goals = [Ũ⃗_goal]
     end
 
+    # Construct phase data
+    phase_data = isnothing(phase_operators) ? nothing : π * randn(length(phase_operators))
+
     return initialize_trajectory(
         state_data,
         state_inits,
@@ -483,6 +491,7 @@ function initialize_trajectory(
         T,
         Δt,
         args...;
+        phase_data=phase_data,
         a_guess=a_guess,
         verbose=verbose,
         kwargs...


### PR DESCRIPTION
For Unitary problem templates, add the ability to pass phase operators. These create global parameters in the named trajectory, and the optimizer is allowed to rotate by these free phases after the pulse.

* Adds free phase infidelity to losses
* Adds free phase objectives
* Introduces if/else block to switch in `phase_operators` arg in problem
* Fixes bugs from previous implementations

**NOTE** A future feature would be to move some information into the problem params, such as phase operators and the goal subspace.

The isomorphisms are also updated to account for type conversion issues, with new tests. 